### PR TITLE
Fix infinite digest loops in Chrome

### DIFF
--- a/angular-jqcloud.js
+++ b/angular-jqcloud.js
@@ -37,7 +37,9 @@ angular.module('angular-jqcloud', []).directive('jqcloud', ['$parse', function($
       
       $scope.$watchCollection('words', function() {
         $scope.$evalAsync(function() {
-          $elem.jQCloud('update', $scope.words);
+          var words = [];
+          $.extend(words,$scope.words);
+          $elem.jQCloud('update', words);
         });
       });
     


### PR DESCRIPTION
Looks like $scope.words was updated in the jQcloud lib causing an infinite loop. Passing a copy of the array instead fixed that.
