### PR TITLE
 	Fixed issue with case sensitive attributes

### DIFF
--- a/angular-jqcloud.js
+++ b/angular-jqcloud.js
@@ -1,6 +1,6 @@
 /*!
  * Angular jQCloud
- * For jQCloud 2 (https://github.com/mistic100/jQCloud) 
+ * For jQCloud 2 (https://github.com/mistic100/jQCloud)
  * Copyright 2014 Damien "Mistic" Sorel (http://www.strangeplanet.fr)
  * Licensed under MIT (http://opensource.org/licenses/MIT)
  */
@@ -9,13 +9,13 @@ angular.module('angular-jqcloud', []).directive('jqcloud', ['$parse', function($
   // get existing options
   var defaults = jQuery.fn.jQCloud.defaults.get(),
       jqcOptions = [];
-  
+
   for (var opt in defaults) {
     if (defaults.hasOwnProperty(opt)) {
       jqcOptions.push(opt);
     }
   }
-  
+
   return {
     restrict: 'E',
     template: '<div></div>',
@@ -25,16 +25,17 @@ angular.module('angular-jqcloud', []).directive('jqcloud', ['$parse', function($
     },
     link: function($scope, $elem, $attr) {
       var options = {};
-      
+
       for (var i=0, l=jqcOptions.length; i<l; i++) {
         var opt = jqcOptions[i];
-        if ($attr[opt] !== undefined) {
-          options[opt] = $parse($attr[opt])();
+        var attr = $attr[opt] || $elem.attr(opt);
+        if (attr !== undefined) {
+          options[opt] = $parse(attr)();
         }
       }
-      
+
       jQuery($elem).jQCloud($scope.words, options);
-      
+
       $scope.$watchCollection('words', function() {
         $scope.$evalAsync(function() {
           var words = [];
@@ -42,7 +43,7 @@ angular.module('angular-jqcloud', []).directive('jqcloud', ['$parse', function($
           jQuery($elem).jQCloud('update', words);
         });
       });
-    
+
       $elem.bind('$destroy', function() {
         jQuery($elem).jQCloud('destroy');
       });

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-jqcloud",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Damien \"Mistic\" Sorel",
     "homepage": "http://www.strangeplanet.fr"


### PR DESCRIPTION
Hello,

Case sensitive attributes, such as encodeURI were not working. I fixed this by checking for both angular formatted $attr and case sensitive $elem.attr. Now either attribute type can be used example: auto-resize or autoResize can be used. Previously only auto-resize worked.

Also some whitespace was trimmed, and updated version for bower.

Regards,
Mike