### PR TITLE
adds afterCloudRender callback support in angular directive

### DIFF
--- a/angular-jqcloud.js
+++ b/angular-jqcloud.js
@@ -21,7 +21,8 @@ angular.module('angular-jqcloud', []).directive('jqcloud', ['$parse', function($
     template: '<div></div>',
     replace: true,
     scope: {
-      words: '=words'
+      words: '=words',
+      afterCloudRender: '&'
     },
     link: function($scope, $elem, $attr) {
       var options = {};
@@ -32,6 +33,10 @@ angular.module('angular-jqcloud', []).directive('jqcloud', ['$parse', function($
         if (attr !== undefined) {
           options[opt] = $parse(attr)();
         }
+      }
+
+      if ($scope.afterCloudRender) {
+        options.afterCloudRender = $scope.afterCloudRender;
       }
 
       jQuery($elem).jQCloud($scope.words, options);


### PR DESCRIPTION
afterCloudRender is a very helpful option in jqCloud, however it doesn't work in this directive wrapper due to using $parse() under the hood (can't parse any callback functions passed in as an attribute since it doesn't have access to the parent scope for evaluating the expression). 

Adding support for an `afterCloudRender` callback attribute via the '&' operator allows the parent scope to send in a callback that is called as expected. 